### PR TITLE
Update to log4j2 2.5, lookup fix (incl. test), fixed JSON parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.apache.logging.log4j:log4j-core:2.2'
+    compile 'org.apache.logging.log4j:log4j-core:2.5'
 	compile 'com.fasterxml.jackson.core:jackson-databind:2.5.0'
     testCompile group: 'junit', name: 'junit', version: '4.+'
 }

--- a/src/main/java/io/pivotal/cloudfoundry/JacksonCFVcapApplicationParser.java
+++ b/src/main/java/io/pivotal/cloudfoundry/JacksonCFVcapApplicationParser.java
@@ -3,6 +3,7 @@ package io.pivotal.cloudfoundry;
 import java.util.Collections;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -26,9 +27,9 @@ public class JacksonCFVcapApplicationParser {
 		
 			if (null != vcapAppEnvVar){
 				final ObjectMapper objectMapper = new ObjectMapper();
-				vcapAppData = objectMapper.readValue(vcapAppEnvVar, Map.class);
-				
+				vcapAppData = objectMapper.readValue(vcapAppEnvVar, new TypeReference<Map<String, Object>>() {});
 			}
+			
 		} catch (Exception e) {
 			throw new IllegalStateException("Unable to parse VCAP_APPLICATION environment variable; VCAP_APPLICATION=" + vcapAppEnvVar, e);
 		}
@@ -41,7 +42,7 @@ public class JacksonCFVcapApplicationParser {
 
 	
 	public String lookup(String key){
-		return String.valueOf(vcapAppData.get(key)) ;
+		return !vcapAppData.containsKey(key)?null:String.valueOf(vcapAppData.get(key));
 	}
 	
 }

--- a/src/main/java/io/pivotal/cloudfoundry/log4j/CFLookup.java
+++ b/src/main/java/io/pivotal/cloudfoundry/log4j/CFLookup.java
@@ -28,7 +28,7 @@ public class CFLookup implements StrLookup{
 		if(null == value){
 			value = String.format("[Unknown key: %s]", key);
 		}
-		
+		 
 		return value;
 	}
 

--- a/src/test/java/io/pivotal/cloudfoundry/log4j/CFLookupTest.java
+++ b/src/test/java/io/pivotal/cloudfoundry/log4j/CFLookupTest.java
@@ -31,7 +31,7 @@ public class CFLookupTest {
 
 	@Test
 	public void testLookupStringWithKnownKeyReturnsCorrectValue() {
-		String result = lookup.lookup("appName");
+		String result = lookup.lookup("application_name");
 		assertNotNull(result);
 		assertEquals("logproducer", result);
 	}

--- a/src/test/java/io/pivotal/cloudfoundry/log4j/StringAppender.java
+++ b/src/test/java/io/pivotal/cloudfoundry/log4j/StringAppender.java
@@ -39,7 +39,7 @@ public class StringAppender extends AbstractOutputStreamAppender<StringAppender.
 		if (nullablePatternString == null) {
 			layout = PatternLayout.createDefaultLayout();
 		} else {
-			layout = PatternLayout.createLayout(nullablePatternString,
+			layout = PatternLayout.createLayout(nullablePatternString,null,
 					configuration, null, null, true, false, null, null);
 		}
 
@@ -75,7 +75,7 @@ public class StringAppender extends AbstractOutputStreamAppender<StringAppender.
 
 		protected StringOutputStreamManager(ByteArrayOutputStream os,
 				String streamName, Layout<?> layout) {
-			super(os, streamName, layout);
+			super(os, streamName, layout, true);
 			stream = os;
 		}
 


### PR DESCRIPTION
- Update to log4j2 2.5 (method signature changes in StringAppender)
- Fixed lookup mechanism & test (JacksonCFVcapApplicationParser return the string "null" instead of a null value - the null check in CFLookup will always fail...)
- Added type reference in Jackson's ObjectMapper - returns null otherwise in my environment
